### PR TITLE
fix(testing): improve error testing practices with specific error types

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -27,6 +27,29 @@
 - Test both positive and negative cases
 - Verify error messages and user output
 
+### Error Testing Best Practices
+- **ALWAYS use `assert.ErrorIs()` for checking specific errors** instead of `assert.Contains(t, err.Error(), "error message")`
+- **NEVER use both `assert.Error(t, err)` and `assert.ErrorIs(t, err, specificError)`** - `assert.ErrorIs()` already checks that the error is not nil
+- Create specific error variables in `*_errors.go` files for each error type
+- Use `errors.New()` or `fmt.Errorf()` with `%w` to wrap errors with context
+- Example:
+  ```go
+  // ✅ GOOD: Use specific errors with assert.ErrorIs()
+  assert.ErrorIs(t, err, ErrGitRepositoryNotFound)
+  
+  // ❌ BAD: Don't use string matching with assert.Contains()
+  assert.Contains(t, err.Error(), "not a valid Git repository: .git directory not found")
+  
+  // ❌ BAD: Don't use redundant error checking
+  assert.Error(t, err)
+  assert.ErrorIs(t, err, ErrGitRepositoryNotFound)
+  ```
+- Define errors in package-specific `errors.go` files:
+  ```go
+  // pkg/cgwt/errors.go
+  var ErrGitRepositoryNotFound = errors.New("not a valid Git repository: .git directory not found")
+  ```
+
 ### What Constitutes an Adapter
 - **Adapters**: Interfaces that abstract external systems (file system, network, databases)
 - Examples: `pkg/fs` (file system operations), future network clients, database clients

--- a/pkg/cgwt/errors.go
+++ b/pkg/cgwt/errors.go
@@ -1,0 +1,37 @@
+package cgwt
+
+import "errors"
+
+// Error definitions for CGWT package.
+var (
+	// Git repository errors.
+	ErrGitRepositoryNotFound     = errors.New("not a valid Git repository: .git directory not found")
+	ErrGitRepositoryNotDirectory = errors.New("not a valid Git repository: .git exists but is not a directory")
+	ErrGitRepositoryInvalid      = errors.New("not a valid Git repository")
+
+	// Repository and branch errors.
+	ErrRepositoryURLEmpty                   = errors.New("repository URL cannot be empty")
+	ErrBranchNameEmpty                      = errors.New("branch name cannot be empty")
+	ErrRepositoryNameEmptyAfterSanitization = errors.New("repository name is empty after sanitization")
+	ErrBranchNameEmptyAfterSanitization     = errors.New("branch name is empty after sanitization")
+
+	// Configuration errors.
+	ErrConfigurationNotInitialized = errors.New("configuration is not initialized")
+
+	// Workspace errors.
+	ErrWorkspaceFileMalformed            = errors.New("invalid .code-workspace file: malformed JSON")
+	ErrRepositoryNotFoundInWorkspace     = errors.New("repository not found in workspace")
+	ErrInvalidRepositoryInWorkspace      = errors.New("invalid repository in workspace")
+	ErrInvalidRepositoryInWorkspaceNoGit = errors.New("invalid repository in workspace - .git directory not found")
+	ErrMultipleWorkspaces                = errors.New("failed to handle multiple workspaces")
+	ErrWorkspaceFileRead                 = errors.New("failed to parse workspace file")
+	ErrWorkspaceFileReadError            = errors.New("failed to read workspace file")
+	ErrWorkspaceDetection                = errors.New("failed to detect workspace mode")
+	ErrWorkspaceEmptyFolders             = errors.New("workspace file must contain non-empty folders array")
+
+	// Status management errors.
+	ErrAddWorktreeToStatus      = errors.New("failed to add worktree to status")
+	ErrRemoveWorktreeFromStatus = errors.New("failed to remove worktree from status")
+	ErrGetWorktreeStatus        = errors.New("failed to get worktree status")
+	ErrListWorktrees            = errors.New("failed to list worktrees")
+)

--- a/pkg/cgwt/status_test.go
+++ b/pkg/cgwt/status_test.go
@@ -84,8 +84,7 @@ func TestAddWorktreeToStatus_Error(t *testing.T) {
 	err := cgwt.(*realCGWT).addWorktreeToStatus(repoName, branch, worktreePath, workspacePath)
 
 	// Assert
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to add worktree to status")
+	assert.ErrorIs(t, err, ErrAddWorktreeToStatus)
 }
 
 func TestRemoveWorktreeFromStatus(t *testing.T) {
@@ -147,8 +146,7 @@ func TestRemoveWorktreeFromStatus_Error(t *testing.T) {
 	err := cgwt.(*realCGWT).removeWorktreeFromStatus(repoName, branch)
 
 	// Assert
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to remove worktree from status")
+	assert.ErrorIs(t, err, ErrRemoveWorktreeFromStatus)
 }
 
 func TestGetWorktreeStatus(t *testing.T) {
@@ -217,9 +215,8 @@ func TestGetWorktreeStatus_Error(t *testing.T) {
 	repo, err := cgwt.(*realCGWT).getWorktreeStatus(repoName, branch)
 
 	// Assert
-	assert.Error(t, err)
 	assert.Nil(t, repo)
-	assert.Contains(t, err.Error(), "failed to get worktree status")
+	assert.ErrorIs(t, err, ErrGetWorktreeStatus)
 }
 
 func TestListAllWorktrees(t *testing.T) {
@@ -290,7 +287,6 @@ func TestListAllWorktrees_Error(t *testing.T) {
 	repos, err := cgwt.(*realCGWT).listAllWorktrees()
 
 	// Assert
-	assert.Error(t, err)
 	assert.Nil(t, repos)
-	assert.Contains(t, err.Error(), "failed to list worktrees")
+	assert.ErrorIs(t, err, ErrListWorktrees)
 }

--- a/pkg/cgwt/workspace.go
+++ b/pkg/cgwt/workspace.go
@@ -47,18 +47,18 @@ func (c *realCGWT) parseWorkspaceFile(filename string) (*WorkspaceConfig, error)
 	// Read workspace file
 	content, err := c.fs.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read workspace file: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrWorkspaceFileReadError, err)
 	}
 
 	// Parse JSON
 	var config WorkspaceConfig
 	if err := json.Unmarshal(content, &config); err != nil {
-		return nil, fmt.Errorf("invalid .code-workspace file: malformed JSON")
+		return nil, ErrWorkspaceFileMalformed
 	}
 
 	// Validate folders array
 	if config.Folders == nil {
-		return nil, fmt.Errorf("workspace file must contain non-empty folders array")
+		return nil, ErrWorkspaceEmptyFolders
 	}
 
 	// Filter out null values and validate structure
@@ -83,7 +83,7 @@ func (c *realCGWT) parseWorkspaceFile(filename string) (*WorkspaceConfig, error)
 
 	// Check if we have any valid folders after filtering
 	if len(validFolders) == 0 {
-		return nil, fmt.Errorf("workspace file must contain non-empty folders array")
+		return nil, ErrWorkspaceEmptyFolders
 	}
 
 	config.Folders = validFolders

--- a/pkg/cgwt/workspace_test.go
+++ b/pkg/cgwt/workspace_test.go
@@ -78,8 +78,7 @@ func TestCGWT_Run_InvalidWorkspaceJSON(t *testing.T) {
 	mockFS.EXPECT().ReadFile("project.code-workspace").Return([]byte(`{invalid json`), nil).Times(1)
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid .code-workspace file: malformed JSON")
+	assert.ErrorIs(t, err, ErrWorkspaceFileMalformed)
 }
 
 func TestCGWT_Run_MissingRepository(t *testing.T) {
@@ -112,8 +111,7 @@ func TestCGWT_Run_MissingRepository(t *testing.T) {
 	mockFS.EXPECT().Exists("frontend").Return(false, nil).AnyTimes()
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "repository not found in workspace: ./frontend")
+	assert.ErrorIs(t, err, ErrRepositoryNotFoundInWorkspace)
 }
 
 func TestCGWT_Run_InvalidRepository(t *testing.T) {
@@ -149,8 +147,7 @@ func TestCGWT_Run_InvalidRepository(t *testing.T) {
 	mockFS.EXPECT().Exists("frontend/.git").Return(false, nil).AnyTimes()
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid repository in workspace: ./frontend - .git directory not found")
+	assert.ErrorIs(t, err, ErrInvalidRepositoryInWorkspaceNoGit)
 }
 
 func TestCGWT_Run_GitStatusError(t *testing.T) {
@@ -189,8 +186,7 @@ func TestCGWT_Run_GitStatusError(t *testing.T) {
 	mockGit.EXPECT().Status("frontend").Return("", assert.AnError).AnyTimes()
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid repository in workspace: ./frontend - assert.AnError general error for testing")
+	assert.ErrorIs(t, err, ErrInvalidRepositoryInWorkspace)
 }
 
 func TestCGWT_Run_MultipleWorkspaceFiles(t *testing.T) {
@@ -209,8 +205,7 @@ func TestCGWT_Run_MultipleWorkspaceFiles(t *testing.T) {
 	mockFS.EXPECT().Glob("*.code-workspace").Return([]string{"project1.code-workspace", "project2.code-workspace"}, nil).Times(1)
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to handle multiple workspaces")
+	assert.ErrorIs(t, err, ErrMultipleWorkspaces)
 }
 
 func TestCGWT_Run_WorkspaceFileReadError(t *testing.T) {
@@ -232,8 +227,7 @@ func TestCGWT_Run_WorkspaceFileReadError(t *testing.T) {
 	mockFS.EXPECT().ReadFile("project.code-workspace").Return(nil, assert.AnError).Times(1)
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse workspace file")
+	assert.ErrorIs(t, err, ErrWorkspaceFileReadError)
 }
 
 func TestCGWT_Run_WorkspaceGlobError(t *testing.T) {
@@ -252,8 +246,7 @@ func TestCGWT_Run_WorkspaceGlobError(t *testing.T) {
 	mockFS.EXPECT().Glob("*.code-workspace").Return(nil, assert.AnError).Times(1)
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to detect workspace mode")
+	assert.ErrorIs(t, err, ErrWorkspaceDetection)
 }
 
 func TestCGWT_Run_WorkspaceVerboseMode(t *testing.T) {
@@ -318,6 +311,5 @@ func TestCGWT_Run_EmptyWorkspace(t *testing.T) {
 	mockFS.EXPECT().ReadFile("project.code-workspace").Return([]byte(workspaceJSON), nil).AnyTimes()
 
 	err := cgwt.CreateWorkTree()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "workspace file must contain non-empty folders array")
+	assert.ErrorIs(t, err, ErrWorkspaceEmptyFolders)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ func NewManager() Manager {
 func (c *realManager) LoadConfig(configPath string) (*Config, error) {
 	// Check if config file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("config file not found: %s", configPath)
+		return nil, fmt.Errorf("%w: %s", ErrConfigFileNotFound, configPath)
 	}
 
 	// Read config file
@@ -47,7 +47,7 @@ func (c *realManager) LoadConfig(configPath string) (*Config, error) {
 	// Parse YAML
 	var config Config
 	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrConfigFileParse, err)
 	}
 
 	// Validate configuration
@@ -78,7 +78,7 @@ func (c *realManager) DefaultConfig() *Config {
 // Validate validates the configuration values.
 func (c *Config) Validate() error {
 	if c.BasePath == "" {
-		return fmt.Errorf("base_path cannot be empty")
+		return ErrBasePathEmpty
 	}
 
 	// Check if base path is accessible (can be created if it doesn't exist)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -36,7 +36,11 @@ func TestConfig_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.config.Validate()
 			if tt.wantErr {
-				assert.Error(t, err)
+				if tt.config.BasePath == "" {
+					assert.ErrorIs(t, err, ErrBasePathEmpty)
+				} else {
+					assert.Error(t, err)
+				}
 			} else {
 				assert.NoError(t, err)
 			}
@@ -76,9 +80,8 @@ func TestRealManager_LoadConfig_FileNotFound(t *testing.T) {
 	manager := NewManager()
 	config, err := manager.LoadConfig("/nonexistent/path/config.yaml")
 
-	assert.Error(t, err)
 	assert.Nil(t, config)
-	assert.Contains(t, err.Error(), "config file not found")
+	assert.ErrorIs(t, err, ErrConfigFileNotFound)
 }
 
 func TestRealManager_LoadConfig_InvalidYAML(t *testing.T) {
@@ -95,9 +98,8 @@ invalid: yaml: structure: here`
 	manager := NewManager()
 	config, err := manager.LoadConfig(configPath)
 
-	assert.Error(t, err)
 	assert.Nil(t, config)
-	assert.Contains(t, err.Error(), "failed to parse config file")
+	assert.ErrorIs(t, err, ErrConfigFileParse)
 }
 
 func TestLoadConfigWithFallback_WithValidFile(t *testing.T) {

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -1,0 +1,12 @@
+package config
+
+import "errors"
+
+// Error definitions for config package.
+var (
+	// Configuration file errors.
+	ErrConfigFileNotFound = errors.New("config file not found")
+	ErrConfigFileParse    = errors.New("failed to parse config file")
+	// Configuration validation errors.
+	ErrBasePathEmpty = errors.New("base_path cannot be empty")
+)

--- a/pkg/fs/atomic_operations_test.go
+++ b/pkg/fs/atomic_operations_test.go
@@ -138,7 +138,7 @@ func TestFileLock(t *testing.T) {
 		unlock2, err := fs.FileLock(testFile)
 		if err != nil {
 			// Lock acquisition failed as expected
-			assert.Contains(t, err.Error(), "lock")
+			assert.ErrorIs(t, err, ErrFileLock)
 		} else {
 			// Lock acquisition succeeded (system doesn't enforce locks)
 			unlock2()

--- a/pkg/fs/errors.go
+++ b/pkg/fs/errors.go
@@ -1,0 +1,9 @@
+package fs
+
+import "errors"
+
+// Error definitions for fs package.
+var (
+	// File lock errors.
+	ErrFileLock = errors.New("lock")
+)

--- a/pkg/status/errors.go
+++ b/pkg/status/errors.go
@@ -1,0 +1,11 @@
+package status
+
+import "errors"
+
+// Error definitions for status package.
+var (
+	// Worktree management errors.
+	ErrWorktreeAlreadyExists       = errors.New("worktree already exists")
+	ErrWorktreeNotFound            = errors.New("worktree not found")
+	ErrConfigurationNotInitialized = errors.New("configuration is not initialized")
+)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -59,7 +59,7 @@ func (s *realManager) AddWorktree(repoName, branch, worktreePath, workspacePath 
 	// Check for duplicate entry
 	for _, repo := range status.Repositories {
 		if repo.Name == repoName && repo.Branch == branch {
-			return fmt.Errorf("worktree already exists for repository %s branch %s", repoName, branch)
+			return fmt.Errorf("%w for repository %s branch %s", ErrWorktreeAlreadyExists, repoName, branch)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (s *realManager) RemoveWorktree(repoName, branch string) error {
 	}
 
 	if !found {
-		return fmt.Errorf("worktree not found for repository %s branch %s", repoName, branch)
+		return fmt.Errorf("%w for repository %s branch %s", ErrWorktreeNotFound, repoName, branch)
 	}
 
 	// Update repositories list
@@ -131,7 +131,7 @@ func (s *realManager) GetWorktree(repoName, branch string) (*Repository, error) 
 		}
 	}
 
-	return nil, fmt.Errorf("worktree not found for repository %s branch %s", repoName, branch)
+	return nil, fmt.Errorf("%w for repository %s branch %s", ErrWorktreeNotFound, repoName, branch)
 }
 
 // ListAllWorktrees lists all tracked worktrees.
@@ -148,7 +148,7 @@ func (s *realManager) ListAllWorktrees() ([]Repository, error) {
 // getStatusFilePath returns the status file path from configuration.
 func (s *realManager) getStatusFilePath() (string, error) {
 	if s.config == nil {
-		return "", fmt.Errorf("configuration is not initialized")
+		return "", ErrConfigurationNotInitialized
 	}
 
 	if s.config.StatusFile == "" {

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -106,8 +106,7 @@ func TestAddWorktree_Duplicate(t *testing.T) {
 	err := manager.AddWorktree(repoName, branch, worktreePath, workspacePath)
 
 	// Assert
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "worktree already exists")
+	assert.ErrorIs(t, err, ErrWorktreeAlreadyExists)
 }
 
 func TestRemoveWorktree(t *testing.T) {
@@ -218,8 +217,7 @@ func TestRemoveWorktree_NotFound(t *testing.T) {
 	err := manager.RemoveWorktree(repoName, branch)
 
 	// Assert
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "worktree not found")
+	assert.ErrorIs(t, err, ErrWorktreeNotFound)
 }
 
 func TestGetWorktree(t *testing.T) {
@@ -317,9 +315,8 @@ func TestGetWorktree_NotFound(t *testing.T) {
 	repo, err := manager.GetWorktree(repoName, branch)
 
 	// Assert
-	assert.Error(t, err)
 	assert.Nil(t, repo)
-	assert.Contains(t, err.Error(), "worktree not found")
+	assert.ErrorIs(t, err, ErrWorktreeNotFound)
 }
 
 func TestListAllWorktrees(t *testing.T) {


### PR DESCRIPTION
- Replace assert.Contains() with assert.ErrorIs() for specific error checking
- Remove redundant assert.Error() calls when using assert.ErrorIs()
- Create specific error types in *_errors.go files for each package
- Update source code to use specific error types with proper wrapping
- Add comprehensive error testing best practices to .cursorrules
- Fix linting issues with comment periods
- Ensure all tests pass with proper error type checking